### PR TITLE
Discord support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Async ParrotBot
-An asynchronous rewrite of CUSF slack tools, which will eventually support multiple tools.
+An asynchronous rewrite of CUSF slack tools, now supporting both Slack and Discord.
 
 ## Parrotmaker
 <pre>
@@ -10,6 +10,11 @@ use it with `/parrot message`
 
 ![parrotmaker example](parrotmaker_example.gif)
 
+This does not really work in Discord due to the combination 
+of the 2000 character message limit and emojis counted by their 
+long name + emoji id. 
+A 3x3 font could work but it would be practically illegible.
+
 ## PONG
 
 Pong was removed as it would have been a bit annoying to reimplement for now.
@@ -18,6 +23,7 @@ Something better will come, probably. I think. Maybe not, we'll see.
 ## Google Drive Auto Upload
 Literally the only thing useful about parrotbot. But it's boring so that's why
 it's at the bottom.
+Works both on Slack and Discord.
 
 ## Setting it up
 

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -1,6 +1,11 @@
 slack_app_token: xapp-...
 slack_bot_token: xoxb-...
 
+discord:
+  token: ...
+  guild_id: ...
+  min_sync_roleid: ...
+
 features_enabled:
   - live_archive
   - parrotmaker
@@ -10,9 +15,12 @@ live_archive:
   archive_path: /var/opt/async-parrotbot/slack-archive
 
 gdrive:
-  local_path: /var/opt/async-parrotbot/files
-  remote_path: parrotbot-gdrive:"999 Slack Staging"
-  remote_nice_name: 999 Slack Staging
+  slack_local_path: /var/opt/async-parrotbot/files
+  slack_remote_path: parrotbot-gdrive:"999 Slack Staging"
+  slack_remote_nice_name: 999 Slack Staging
+  discord_local_path: /var/opt/async-parrotbot/files/discord
+  discord_remote_path: parrotbot-gdrive:"998 Discord Staging"
+  discord_remote_nice_name: 998 Discord Staging
   rclone_log_path: /var/log/async-parrotbot/rclone-log
 
 log:

--- a/gdrive.py
+++ b/gdrive.py
@@ -12,16 +12,16 @@ async def handle_file_shared(client, event, say, ack):
 
 	normalised_name = user_data['real_name'].replace(" ", "_")
 	file_url = file_data['url_private_download']
-	file_path = Path(f"{config['gdrive']['local_path']}") / f"{normalised_name}" / file_data['name']
+	file_path = Path(f"{config['gdrive']['slack_local_path']}") / f"{normalised_name}" / file_data['name']
 	headers = {
 		"Authorization": f"Bearer {config['slack_bot_token']}",
 	}
 	await download_file(file_path, file_url, headers)
 
-	dir_nice_name = f"{config['gdrive']['remote_nice_name']}/{normalised_name}"
+	dir_nice_name = f"{config['gdrive']['slack_remote_nice_name']}/{normalised_name}"
 	msg_data = (await say(f"File uploading to {dir_nice_name}...")).data
 	rclone_log = Path(config['gdrive']['rclone_log_path'])
-	returncode = await rclone_sync(config['gdrive']['local_path'], config['gdrive']['remote_path'], rclone_log)
+	returncode = await rclone_sync(config['gdrive']['slack_local_path'], config['gdrive']['slack_remote_path'], rclone_log)
 
 	await client.chat_update(
 		channel  = msg_data['channel'],

--- a/gdrive.py
+++ b/gdrive.py
@@ -11,42 +11,68 @@ async def handle_file_shared(client, event, say, ack):
 	print("File shared by ", user_data['real_name'], flush=True, file=info_stream)
 
 	normalised_name = user_data['real_name'].replace(" ", "_")
-	dir_path = Path(f"{config['gdrive']['local_path']}") / f"{normalised_name}"
+	file_url = file_data['url_private_download']
+	file_path = Path(f"{config['gdrive']['local_path']}") / f"{normalised_name}" / file_data['name']
+	headers = {
+		"Authorization": f"Bearer {config['slack_bot_token']}",
+	}
+	await download_file(file_path, file_url, headers)
+
 	dir_nice_name = f"{config['gdrive']['remote_nice_name']}/{normalised_name}"
-
 	msg_data = (await say(f"File uploading to {dir_nice_name}...")).data
-
-	await download_file(dir_path, file_data)
 	rclone_log = Path(config['gdrive']['rclone_log_path'])
-	rclone_log.parent.mkdir(exist_ok=True, parents=True)
-	with open(rclone_log, 'a+') as rclone_log_file:
-		process = await asyncio.create_subprocess_exec('rclone',
-													   'sync', config['gdrive']['local_path'], config['gdrive']['remote_path'],
-													   stdout=rclone_log_file, stderr=rclone_log_file)
-	await process.wait()
-	if process.returncode != 0:
-		print(f"Error code {process.returncode} occured during uploading to the remote via rclone. "
-			  f"See {str(rclone_log)} for details.", file=err_stream)
+	returncode = await rclone_sync(config['gdrive']['local_path'], config['gdrive']['remote_path'], rclone_log)
 
 	await client.chat_update(
 		channel  = msg_data['channel'],
 		ts       = msg_data['ts'],
-		text     = f"File uploaded to {dir_nice_name}" if process.returncode == 0 else f"File *failed* to upload to {dir_nice_name}"
+		text     = f"File uploaded to {dir_nice_name}" if returncode == 0 else f"File *failed* to upload to {dir_nice_name}"
 	)
 
+# We use listen() instead of event() to avoid overwriting the normal command parsing and to respond to events
+# from multiple files (i.e. when writing future features)
+@dc_app.listen()
+async def on_message(msg: discord.Message):
+	if msg.attachments:
+		print(f"{len(msg.attachments)} file(s) shared by {msg.author.display_name}", flush=True, file=info_stream)
+		normalised_name = msg.author.display_name.replace(" ", "_")
+		file_paths = [Path(f"{config['gdrive']['discord_local_path']}") / f"{normalised_name}" / a.filename for a in msg.attachments]
+		file_urls = [a.url for a in msg.attachments]
+		coros = [download_file(fp, url) for fp, url in zip(file_paths, file_urls)]
+		await asyncio.gather(*coros)
 
-async def download_file(dir_path, file_data):
-	header = {
-		"Authorization": f"Bearer {config['slack_bot_token']}",
-	}
-	dir_path.mkdir(exist_ok=True, parents=True)
-	async with aiohttp.ClientSession(headers=header) as session:
-		async with session.get(file_data['url_private_download']) as resp:
+		dir_nice_name = f"{config["gdrive"]["discord_remote_nice_name"]}/{normalised_name}"
+		status_msg = await msg.reply(f"{len(msg.attachments)} file(s) uploading to {dir_nice_name}...")
+
+		rclone_log = Path(config['gdrive']['rclone_log_path'])
+		returncode = await rclone_sync(config['gdrive']['discord_local_path'], config['gdrive']['discord_remote_path'], rclone_log)
+		updated_status = (f"{len(msg.attachments)} file(s) "
+					   f"{'uploaded' if returncode == 0 else '**failed** to upload'} to {dir_nice_name}")
+		await status_msg.edit(content=updated_status)
+
+
+async def rclone_sync(local: str, remote: str, log: Path):
+	log.parent.mkdir(exist_ok=True, parents=True)
+	with open(log, 'a+') as rclone_log_file:
+		process = await asyncio.create_subprocess_exec('rclone',
+													   'sync', local, remote,
+													   stdout=rclone_log_file, stderr=rclone_log_file)
+	await process.wait()
+	if process.returncode != 0:
+		print(f"Error code {process.returncode} occured during uploading to the remote via rclone. "
+			  f"See {str(log)} for details.", file=err_stream)
+	return process.returncode
+
+
+async def download_file(file_path: Path, file_url, headers = None):
+	file_path.parent.mkdir(exist_ok=True, parents=True)
+	async with aiohttp.ClientSession(headers=headers) as session:
+		async with session.get(file_url) as resp:
 			if resp.status == 200:
-				with open(dir_path / file_data['name'], 'wb') as f:
+				with open(file_path, 'wb') as f:
 					async for chunk in resp.content.iter_chunked(4096):
 						f.write(chunk)
 
 			else:
 				print(f"Received non-200 response when downloading file "
-					  f"{file_data['url_private_download']}", file=err_stream)
+					  f"{file_url}", file=err_stream)

--- a/main.py
+++ b/main.py
@@ -8,6 +8,10 @@ if config['features_enabled'] is not None:
 
 print("Starting parrotbot...", flush=True, file=info_stream)
 
+@dc_app.event
+async def on_ready():
+	print(f"Logged in to Discord as {dc_app.user} (ID: {dc_app.user.id})", file=info_stream)
+
 
 @slack_app.command("/parrotcheckhealth")
 async def parrotcheckhealth(client, ack, body, say):
@@ -47,7 +51,8 @@ async def main():
 				print(f"Joined {chan['name']}", flush=True, file=info_stream)
 		cursor = conversations['response_metadata']['next_cursor']
 	slack_handler = AsyncSocketModeHandler(slack_app, config['slack_app_token'])
-	await slack_handler.start_async()
+
+	await asyncio.gather(slack_handler.start_async(), dc_app.start(token=config['discord_token']))
 
 if __name__ == "__main__":
 	import asyncio

--- a/shared.py
+++ b/shared.py
@@ -71,6 +71,8 @@ config = yaml.load(open(config_file), Loader=yaml.loader.FullLoader)
 
 intents = discord.Intents.default()
 intents.message_content = True
+intents.members = True
+guild = discord.Object(id=config['discord']['guild_id'])
 
 dc_app = commands.Bot(command_prefix='$', description="Testy-test", intents=intents)
 slack_app = AsyncApp(token = config['slack_bot_token'])

--- a/shared.py
+++ b/shared.py
@@ -74,5 +74,5 @@ intents.message_content = True
 intents.members = True
 guild = discord.Object(id=config['discord']['guild_id'])
 
-dc_app = commands.Bot(command_prefix='$', description="Testy-test", intents=intents)
+dc_app = commands.Bot(command_prefix='$', help_command=None, intents=intents)
 slack_app = AsyncApp(token = config['slack_bot_token'])


### PR DESCRIPTION
Added Discord support, `/parrotcheckhealth` and the Google Drive synchronization works without problems on both platforms. 
Parrotmaker unfortunately does not work in Discord, due to the 2000 character limit of messages and the fact that emojis are counted as (emoji long name length + id length) characters. 
Embeds + a smaller font could work better as they have a max 6000 character length, but they don't span the entire message window. Another alternative is uploading a text file like it is done for `/parrotcheckhealth` but this would limit the emojis to Unicode supported emojis which are not fun. Maybe generating a GIF file and posting it is the best looking way to do it, but that is a large workaround so I am not doing it right now.

Config example is updated to show the new necessary options.
Also at the moment the bot needs to run *both* on Slack and Discord and cannot only do just one. This is probably a not too hard of a fix, probably best done by writing custom decorators that do not do anything if a platform is opted out of.
This is outside of our use case at the moment so I am not implementing this right now.